### PR TITLE
Mayhem integration for some LibFuzzer binaries

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,92 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PROJECTNAME: image
+  BMP_MAYHEMFILE: Mayhem/mbp.mayhemfile
+  EXR_MAYHEMFILE: Mayhem/exr.mayhemfile
+  ICO_MAYHEMFILE: Mayhem/ico.mayhemfile
+  JPEG_MAYHEMFILE: Mayhem/jpg.mayhemfile
+  WEBP_MAYHEMFILE: Mayhem/webp.mayhemfile
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Start analysis for BMP
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.BMP_MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Start analysis for EXR
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.EXR_MAYHEMFILE }}
+          sarif-output: sarif
+      
+      - name: Start analysis for ICO
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.ICO_MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Start analysis for JPEG
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.JPEG_MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Start analysis for WEBP
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.WEBP_MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -50,6 +50,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.mayhem
 
       - name: Start analysis for BMP
         uses: ForAllSecure/mcode-action@v1

--- a/Dockerfile.mayhem
+++ b/Dockerfile.mayhem
@@ -1,0 +1,23 @@
+# Use Rust to build
+FROM rustlang/rust:nightly as builder
+
+# Add source code to the build stage.
+ADD . /image
+WORKDIR /image
+
+RUN cargo install cargo-fuzz
+
+# BUILD INSTRUCTIONS
+WORKDIR /image/fuzz
+RUN cargo +nightly fuzz build fuzzer_script_bmp && \
+    cargo +nightly fuzz build fuzzer_script_exr && \
+    cargo +nightly fuzz build fuzzer_script_ico && \
+    cargo +nightly fuzz build fuzzer_script_jpeg && \
+    cargo +nightly fuzz build fuzzer_script_webp
+# Output binaries are placed in /image/fuzz/target/x86_64-unknown-linux-gnu/release/
+
+# Package Stage -- we package for a plain Ubuntu machine
+FROM --platform=linux/amd64 ubuntu:20.04
+
+# Copy the binary from the build stage to an Ubuntu docker image
+COPY --from=builder /image/fuzz/target/x86_64-unknown-linux-gnu/release/fuzzer_script_bmp /image/fuzz/target/x86_64-unknown-linux-gnu/release/fuzzer_script_exr /image/fuzz/target/x86_64-unknown-linux-gnu/release/fuzzer_script_ico /image/fuzz/target/x86_64-unknown-linux-gnu/release/fuzzer_script_jpeg /image/fuzz/target/x86_64-unknown-linux-gnu/release/fuzzer_script_webp /

--- a/Mayhem/bmp.mayhemfile
+++ b/Mayhem/bmp.mayhemfile
@@ -1,0 +1,6 @@
+project: image
+target: fuzzer_script_bmp
+image: ghcr.io/aaronjsteele/image:latest
+
+cmds:
+  - cmd: /fuzzer_script_bmp

--- a/Mayhem/exr.mayhemfile
+++ b/Mayhem/exr.mayhemfile
@@ -1,0 +1,6 @@
+project: image
+target: fuzzer_script_exr
+image: ghcr.io/aaronjsteele/image:latest
+
+cmds:
+  - cmd: /fuzzer_script_exr

--- a/Mayhem/ico.mayhemfile
+++ b/Mayhem/ico.mayhemfile
@@ -1,0 +1,6 @@
+project: image
+target: fuzzer_script_ico
+image: ghcr.io/aaronjsteele/image:latest
+
+cmds:
+  - cmd: /fuzzer_script_ico

--- a/Mayhem/jpeg.mayhemfile
+++ b/Mayhem/jpeg.mayhemfile
@@ -1,0 +1,6 @@
+project: image
+target: fuzzer_script_jpeg
+image: ghcr.io/aaronjsteele/image:latest
+
+cmds:
+  - cmd: /fuzzer_script_jpeg

--- a/Mayhem/webp.mayhemfile
+++ b/Mayhem/webp.mayhemfile
@@ -1,0 +1,6 @@
+project: image
+target: fuzzer_script_webp
+image: ghcr.io/aaronjsteele/image:latest
+
+cmds:
+  - cmd: /fuzzer_script_webp


### PR DESCRIPTION
Initial integration of Mayhem with the `image` repository. This includes a `Dockerfile`, Mayhemfiles for all the fuzzed binaries, and the GitHub action.

Mayhem fuzzing was implemented for a sampling of the LibFuzzer fuzzing binaries in this repository. The other binaries could be integrated into the Mayhem workflow very easily. Additional work could also be done to integrate the AFL fuzzers also included in the project.